### PR TITLE
Update to sync

### DIFF
--- a/android/src/mediabrowser/apiinteraction/android/sync/AuthenticatorService.java
+++ b/android/src/mediabrowser/apiinteraction/android/sync/AuthenticatorService.java
@@ -15,13 +15,6 @@ import android.os.IBinder;
  */
 public class AuthenticatorService extends Service {
 
-    // Constants
-    // The authority for the sync adapter's content provider
-    public static final String AUTHORITY = "emby.media";
-    // An account type, in the form of a domain name
-    private static final String ACCOUNT_TYPE = "emby.media";
-    // The account name
-    private static final String ACCOUNT_NAME = "sync";
     private Authenticator mAuthenticator;
 
     /**
@@ -30,15 +23,15 @@ public class AuthenticatorService extends Service {
      * @return Handle to application's account (not guaranteed to resolve unless CreateSyncAccount()
      *         has been called)
      */
-    public static Account GetAccount() {
+    public static Account GetAccount(SyncAccountInfo accountInfo) {
         // Note: Normally the account name is set to the user's identity (username or email
         // address). However, since we aren't actually using any user accounts, it makes more sense
         // to use a generic string in this case.
         //
         // This string should *not* be localized. If the user switches locale, we would not be
         // able to locate the old account, and may erroneously register multiple accounts.
-        final String accountName = ACCOUNT_NAME;
-        return new Account(accountName, ACCOUNT_TYPE);
+        final String accountName = accountInfo.accountName;
+        return new Account(accountName, accountInfo.accountType);
     }
 
     /**
@@ -46,17 +39,17 @@ public class AuthenticatorService extends Service {
      *
      * @param context Context
      */
-    public static void CreateSyncAccount(Context context) {
+    public static void CreateSyncAccount(Context context, SyncAccountInfo accountInfo) {
         boolean newAccount = false;
 
         // Create account, if it's missing. (Either first run, or user has deleted account.)
-        Account account = GetAccount();
+        Account account = GetAccount(accountInfo);
         AccountManager accountManager = (AccountManager) context.getSystemService(Context.ACCOUNT_SERVICE);
         if (accountManager.addAccountExplicitly(account, null, null)) {
             // Inform the system that this account supports sync
-            ContentResolver.setIsSyncable(account, AUTHORITY, 1);
+            ContentResolver.setIsSyncable(account, accountInfo.authority, 1);
             // Inform the system that this account is eligible for auto sync when the network is up
-            ContentResolver.setSyncAutomatically(account, AUTHORITY, true);
+            ContentResolver.setSyncAutomatically(account, accountInfo.authority, true);
 
             newAccount = true;
         }

--- a/android/src/mediabrowser/apiinteraction/android/sync/OnDemandSync.java
+++ b/android/src/mediabrowser/apiinteraction/android/sync/OnDemandSync.java
@@ -5,6 +5,8 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.os.Bundle;
+import android.text.TextUtils;
+import android.util.Log;
 
 public class OnDemandSync {
 
@@ -14,11 +16,16 @@ public class OnDemandSync {
         this.context = context;
     }
 
-    public void Run() {
+    public void Run(SyncAccountInfo accountInfo) {
 
-        AuthenticatorService.CreateSyncAccount(context);
+        if (!isAccountInfoValid(accountInfo)) {
+            Log.d("OnDemandSync", "Error creating OnDemandSync: AccountInfo is incomplete");
+            return;
+        }
 
-        Account account = AuthenticatorService.GetAccount();
+        AuthenticatorService.CreateSyncAccount(context, accountInfo);
+
+        Account account = AuthenticatorService.GetAccount(accountInfo);
 
         // Pass the settings flags by inserting them in a bundle
         Bundle settingsBundle = new Bundle();
@@ -30,6 +37,13 @@ public class OnDemandSync {
          * Request the sync for the default account, authority, and
          * manual sync settings
          */
-        ContentResolver.requestSync(account, AuthenticatorService.AUTHORITY, settingsBundle);
+        ContentResolver.requestSync(account, accountInfo.authority, settingsBundle);
+    }
+
+    private boolean isAccountInfoValid(SyncAccountInfo accountInfo) {
+        return accountInfo != null
+                && !TextUtils.isEmpty(accountInfo.authority)
+                && !TextUtils.isEmpty(accountInfo.accountName)
+                && !TextUtils.isEmpty(accountInfo.accountType);
     }
 }

--- a/android/src/mediabrowser/apiinteraction/android/sync/SyncAccountInfo.java
+++ b/android/src/mediabrowser/apiinteraction/android/sync/SyncAccountInfo.java
@@ -1,0 +1,19 @@
+package mediabrowser.apiinteraction.android.sync;
+
+/**
+ * Created by Mark on 2015-12-24.
+ */
+public class SyncAccountInfo {
+    // The authority for the sync adapter's content provider
+    public String authority = "emby.media";
+    // An account type, in the form of a domain name
+    public String accountType = "emby.media";
+    // The account name
+    public String accountName = "sync";
+
+    public SyncAccountInfo(String theAuthority, String theAccountType, String theAccountName) {
+        authority = theAuthority;
+        accountType = theAccountType;
+        accountName = theAccountName;
+    }
+}


### PR DESCRIPTION
The current sync implementation hard-codes various values inside the AuthenticatorService. This is problematic because the OS will reject any attempts to install a second android client that also uses sync.

This update allows the developer to instead supply those values to create a unique sync account. The downside to this is that it's possible to have 2 sync accounts registered. I believe that this is the lesser of two evils as I've only tested through adb and don't know if the OS presents a comprehensive dialog to the user explaining that the sync account collision has occured. 